### PR TITLE
Implements resuming of aborted or failed download

### DIFF
--- a/Sources/OlympUs/OlympUs.swift
+++ b/Sources/OlympUs/OlympUs.swift
@@ -127,6 +127,18 @@ public class URLSessionDelegateProxy: NSObject, URLSessionDownloadDelegate {
             proxy.urlSession?(session, downloadTask: downloadTask, didResumeAtOffset: fileOffset, expectedTotalBytes: expectedTotalBytes)
         }
     }
+
+    public func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+        proxies.forEach { proxy in
+            proxy.urlSession?(session, didBecomeInvalidWithError: error)
+        }
+    }
+
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        proxies.forEach { proxy in
+            proxy.urlSession?(session, task: task, didCompleteWithError: error)
+        }
+    }
 }
 
 extension OlympUs.AuthenticationAssets: Codable {}

--- a/Sources/xcinfoCore/Downloader.swift
+++ b/Sources/xcinfoCore/Downloader.swift
@@ -39,20 +39,32 @@ class Downloader {
         return formatter
     }()
 
-    public func start(url: URL, disableSleep: Bool) -> Future<URL, XCAPIError> {
+    public func start(url: URL, disableSleep: Bool, resumeData: Data? = nil) -> Future<URL, XCAPIError> {
         var progressDisplay = ProgressDisplay(ratio: 0, width: 20)
 
         return Future { promise in
-            var request = URLRequest(url: url)
-            request.addValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")
-            request.addValue("gzip, deflate, br", forHTTPHeaderField: "Accept-Encoding")
-            let task = self.olymp.session.downloadTask(with: request)
+            let task: URLSessionDownloadTask
+            if let resumeData = resumeData {
+                task = self.olymp.session.downloadTask(withResumeData: resumeData)
+            } else {
+                var request = URLRequest(url: url)
+                request.addValue("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", forHTTPHeaderField: "Accept")
+                request.addValue("gzip, deflate, br", forHTTPHeaderField: "Accept-Encoding")
+
+                task = self.olymp.session.downloadTask(with: request)
+            }
+
             let download = FileDownload(task: task,
                                         delegateProxy: self.sessionDelegateProxy,
                                         logger: self.logger,
                                         disableSleep: disableSleep)
 
-            self.logger.verbose("[\(Self.dateFormatter.string(from: Date()))] Starting download")
+            if resumeData == nil {
+                self.logger.verbose("[\(Self.dateFormatter.string(from: Date()))] Starting download")
+            } else {
+                self.logger.verbose("[\(Self.dateFormatter.string(from: Date()))] Resuming download")
+            }
+
             self.logger.log("Source: \(url)")
             var hasLoggedTotalSize = false
             var previouslyDisplayedNonANSIProgress = -1
@@ -94,14 +106,23 @@ class Downloader {
                         } else {
                             self.logger.log("Download progress: 100 %")
                         }
+
+                        self.sessionDelegateProxy.remove(proxy: download)
+
                         guard let downloadedURL = download.downloadedURL else {
                             promise(.failure(.couldNotMoveToTemporaryFile))
                             return
                         }
                         promise(.success(downloadedURL))
                     case .failed:
+                        self.sessionDelegateProxy.remove(proxy: download)
+
                         if download.downloadedURL == nil {
-                            promise(.failure(.couldNotMoveToTemporaryFile))
+                            if let resumeData = download.resumeData {
+                                promise(.failure(.recoverableDownloadError(url: url, resumeData: resumeData)))
+                            } else {
+                                promise(.failure(.couldNotMoveToTemporaryFile))
+                            }
                         } else {
                             promise(.failure(.downloadInterrupted))
                         }

--- a/Sources/xcinfoCore/FileDownload.swift
+++ b/Sources/xcinfoCore/FileDownload.swift
@@ -30,6 +30,8 @@ class FileDownload: NSObject, URLSessionDownloadDelegate {
     public private(set) var downloadedURL: URL?
     private var startDate: Date!
 
+    public private(set) var resumeData: Data?
+
     private var totalBytesExpectedToWriteValue: Double = 0
     private var downloadSpeedValues = SpeedMeasurements()
 
@@ -108,7 +110,14 @@ class FileDownload: NSObject, URLSessionDownloadDelegate {
         notify()
     }
 
-    func urlSession(_: URLSession, task _: URLSessionTask, didCompleteWithError _: Error?) {
+    func urlSession(_: URLSession, task _: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error = error as? URLError else {
+            return
+        }
+
+        self.logger.error(error.localizedDescription)
+        resumeData = error.downloadTaskResumeData
+
         state = .failed
         notify()
     }

--- a/Sources/xcinfoCore/FileDownload.swift
+++ b/Sources/xcinfoCore/FileDownload.swift
@@ -31,6 +31,7 @@ class FileDownload: NSObject, URLSessionDownloadDelegate {
     private var startDate: Date!
 
     public private(set) var resumeData: Data?
+    public private(set) var isCancelled = false
 
     private var totalBytesExpectedToWriteValue: Double = 0
     private var downloadSpeedValues = SpeedMeasurements()
@@ -49,7 +50,7 @@ class FileDownload: NSObject, URLSessionDownloadDelegate {
     }
 
     init(task: URLSessionDownloadTask, delegateProxy: URLSessionDelegateProxy, logger: Logger, disableSleep: Bool = false) {
-        name = task.originalRequest?.url?.absoluteString ?? "<unnnamed download>"
+        name = task.originalRequest?.url?.absoluteString ?? task.currentRequest?.url?.absoluteString ?? "<unnnamed download>"
         self.task = task
         self.logger = logger
         super.init()
@@ -117,6 +118,7 @@ class FileDownload: NSObject, URLSessionDownloadDelegate {
 
         self.logger.error(error.localizedDescription)
         resumeData = error.downloadTaskResumeData
+        isCancelled = error.code == .cancelled
 
         state = .failed
         notify()

--- a/Sources/xcinfoCore/InterruptionHandler.swift
+++ b/Sources/xcinfoCore/InterruptionHandler.swift
@@ -1,0 +1,28 @@
+//
+//  Copyright © 2020 xcodereleases.com
+//  MIT license - see LICENSE.md
+//
+
+import Foundation
+
+final class InterruptionHandler {
+    private let signalSource: DispatchSourceSignal
+
+    init(handler: @escaping (Bool) -> Void) {
+        signal(SIGINT, SIG_IGN)
+
+        signalSource = DispatchSource.makeSignalSource(signal: SIGINT)
+
+        var interrupted: sig_atomic_t = 0
+        signalSource.setEventHandler {
+            handler(interrupted == 1)
+            interrupted = 1
+        }
+        signalSource.resume()
+    }
+
+    deinit {
+        signalSource.cancel()
+        signal(SIGINT, SIG_DFL)
+    }
+}

--- a/Sources/xcinfoCore/xcreleasesAPI.swift
+++ b/Sources/xcinfoCore/xcreleasesAPI.swift
@@ -165,6 +165,7 @@ enum XCAPIError: Error, CustomStringConvertible {
     case invalidCache
     case versionNotFound
     case downloadInterrupted
+    case recoverableDownloadError(url: URL, resumeData: Data)
     case couldNotMoveToTemporaryFile
     case couldNotMoveToApplicationsFolder
     case timeout
@@ -177,6 +178,8 @@ enum XCAPIError: Error, CustomStringConvertible {
             return "invalid cache file"
         case .versionNotFound:
             return "version not found"
+        case .recoverableDownloadError:
+            return "download failed"
         case .downloadInterrupted:
             return "download was interrupted"
         case .couldNotMoveToTemporaryFile:


### PR DESCRIPTION
FileDownload relies on URLSessionTaskDelegate's methods to receive and handle errors.
However, it doesn't receive them since these methods are not called in URLSessionDelegateProxy.

This fixes #11. It can be reproduced by switching between different WiFi networks — the timeout error is thrown by URLSession but it isn't handled by FileDownload class.

- [x] Fix errors redirecting from URLSessionDelegateProxy
- [x] Implement download resuming if the task fails with resumeData
- [x] Implement resumeData disk storing in case of download abortion