### PR TITLE
Build universal xcinfo, both arm64 and x86_64.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+jobs:
+  build:
+    runs-on: macOS-latest
+    steps:
+    - name: Test
+      uses: actions/checkout@v2
+    - name: Building a Universal xcinfo
+      run: make
+    - name: Installing
+      run: sudo make install
+    - name: Testing archs
+      run: lipo -archs /usr/local/bin/xcinfo
+    - name: Testing xcinfo
+      run: /usr/local/bin/xcinfo --help

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Testing archs
       run: lipo -archs /usr/local/bin/xcinfo
     - name: Testing xcinfo
-      run: /usr/local/bin/xcinfo --help
+      run: /usr/local/bin/xcinfo list --all --no-ansi

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,22 @@
+prefix=/usr/local
+exec_prefix=$(prefix)
+bindir=$(prefix)/bin
+
+export prefix
+export exec_prefix
+export bindir
+
+all:
+	swift build -c release --arch arm64 --arch x86_64
+
+.PHONY: all install clean cleanup
+
 install:
-	swift build -c release
-	install .build/release/xcinfo /usr/local/bin/xcinfo
+	install -d $(bindir)
+	install -m 0755 .build/apple/Products/Release/xcinfo $(bindir)
+
+clean:
+	swift package clean
+
+cleanup: clean
+	rm -rf .build

--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ SUBCOMMANDS:
 $ git clone https://github.com/xcodereleases/xcinfo.git
 $ cd xcinfo
 $ make
+$ sudo make install
 ```
+
+### Make
+- Build a universal (`arm64` and `x86_64`) xcinfo: `make`
+- Install xcinfo (default to `/usr/local/bin`): `sudo make install` or to other local: `sudo make install prefix=/opt/local`
+- Clean build caches: `make clean`
+- Cleanup all caches: `make cleanup`
 
 ### Mint
 ```


### PR DESCRIPTION
Add more `make` commands: `install`, `clean`, `cleanup`.

Build xcinfo:
`make`

Install xcinfo to `/usr/local`:
`sudo make install` or other local `sudo make install prefix=/opt/local`

Clean build caches:
`make clean`

Cleanup all caches:
`make cleanup`