### PR TITLE
README.md: Removed fulfilled todo - latest argument for install subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ $ brew install xcinfo
 
 ## TODO
 - sudo support without storing user password in memory
-- `latest` argument for install subcommand (e.g. `xcinfo install latest`)
 - man page
 - tests
 - include default data (when github is offline)


### PR DESCRIPTION
I started looking into this, but it seems that this has already been fulfilled. It looks like this can be removed from the `README.md`.

<img width="598" alt="Screen Shot 2022-01-08 at 4 20 19 PM" src="https://user-images.githubusercontent.com/10556242/148664509-841103c3-b2db-472e-8a88-ea4377c993ed.png">
<img width="308" alt="Screen Shot 2022-01-08 at 4 27 43 PM" src="https://user-images.githubusercontent.com/10556242/148664525-5aab5267-7673-43eb-9a45-99ffce7796e5.png">

