### PR TITLE
Build And Release Support

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcinfo.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcinfo.xcscheme
@@ -157,7 +157,7 @@
       <CommandLineArguments>
          <CommandLineArgument
             argument = "install"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "download"
@@ -177,7 +177,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "uninstall"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "info"
@@ -200,8 +200,16 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "&quot;12&quot;"
+            argument = "&quot;13.2&quot;"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-b &quot;13C90&quot;"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-r &quot;RC 1&quot;"
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--no-symlink"

--- a/Sources/xcinfo/download.swift
+++ b/Sources/xcinfo/download.swift
@@ -34,10 +34,18 @@ extension XCInfo {
         )
         var disableSleep: Bool = false
 
+				@Option(name: .shortAndLong, help: "Build version to use (if provided).")
+				var build: String?
+
+				@Option(name: .shortAndLong, help: "Release name to use (if provided).")
+				var release: String?
+
         func run() throws {
             let core = xcinfoCore(verbose: globals.isVerbose, useANSI: globals.useANSI)
             core.download(
                 releaseName: xcodeVersion.asString(),
+								build: build,
+								release: release,
                 updateVersionList: updateList,
                 disableSleep: disableSleep
             )

--- a/Sources/xcinfo/info.swift
+++ b/Sources/xcinfo/info.swift
@@ -22,6 +22,12 @@ extension XCInfo {
         )
         var xcodeVersion: XcodeVersion?
 
+				@Option(name: .shortAndLong, help: "Build version to use (if provided).")
+				var build: String?
+
+				@Option(name: .shortAndLong, help: "Release name to use (if provided).")
+				var release: String?
+
 //        func validate() throws {
 //            if case let .version(versionString) = xcodeVersion {
 //                let normalizedVersion = versionString
@@ -38,7 +44,7 @@ extension XCInfo {
 
         func run() throws {
             let core = xcinfoCore(verbose: globals.isVerbose, useANSI: globals.useANSI)
-            core.info(releaseName: xcodeVersion?.asString())
+            core.info(releaseName: xcodeVersion?.asString(), build: build, release: release)
         }
     }
 }

--- a/Sources/xcinfo/install.swift
+++ b/Sources/xcinfo/install.swift
@@ -54,14 +54,22 @@ extension XCInfo {
         )
         var shouldDeleteXIP: Bool = true
 
+				@Option(name: .shortAndLong, help: "Build version to use (if provided).")
+				var build: String?
+
+				@Option(name: .shortAndLong, help: "Release name to use (if provided).")
+				var release: String?
+
         func run() throws {
             let core = xcinfoCore(verbose: globals.isVerbose, useANSI: globals.useANSI)
             core.install(releaseName: xcodeVersion.asString(),
+												 build: build,
+												 release: release,
                          updateVersionList: updateList,
                          disableSleep: disableSleep,
                          skipSymlinkCreation: skipSymlinkCreation,
                          skipXcodeSelection: skipXcodeSelection,
-                         shouldDeleteXIP: shouldDeleteXIP)
+												 shouldDeleteXIP: shouldDeleteXIP)
         }
     }
 }

--- a/Sources/xcinfo/uninstall.swift
+++ b/Sources/xcinfo/uninstall.swift
@@ -26,9 +26,14 @@ extension XCInfo {
         )
         var updateList: Bool = false
 
+			@Option(name: .shortAndLong, help: "Build version to use (if provided).")
+			var build: String?
+
         func run() throws {
             let core = xcinfoCore(verbose: globals.isVerbose, useANSI: globals.useANSI)
-            core.uninstall(xcodeVersion?.lowercased(), updateVersionList: updateList)
+            core.uninstall(xcodeVersion?.lowercased(),
+													 build: build,
+													 updateVersionList: updateList)
         }
     }
 }

--- a/Sources/xcinfoCore/xcreleasesAPI.swift
+++ b/Sources/xcinfoCore/xcreleasesAPI.swift
@@ -46,6 +46,23 @@ extension Xcode: CustomStringConvertible, CustomDebugStringConvertible {
         return components.joined(separator: " ")
     }
 
+		var releaseTitle: String {
+				switch version.release {
+						case .gm:
+								return "GM"
+						case .gmSeed(let gmSeed):
+								return "GM Seed \(gmSeed)"
+						case .rc(let rc):
+								return "RC \(rc)"
+						case .beta(let beta):
+								return "Beta \(beta)"
+						case .dp(let dp):
+								return "DP \(dp)"
+						case .release:
+								return "Release"
+				}
+		}
+
     private var namedVersion: String {
         var components: [String] = []
         if let number = version.number {


### PR DESCRIPTION
## Problem
I was looking at using Xcinfo for managing Xcode on a CI machine, and noticed it needed me to interact with it quite often.

## Observations
I noticed xcinfo reads the session and user information from the keychain for subsequent use, and was able to inject that whenever I need for xcinfo to pickup during installation. But, if I want the CI to run, and just install a single version, that functionality is not available if that particular version has a beta, seed, rc, gm etc.. So, what if I can specify that instead?

## Implementation
I use the `@Options` for adding build and release to `info`, `install`, and `download`. Which is passed down to filter for filtering to specific versions if provided.

I could have use the regex option, but, I see it introducing two non-blocking issues:
- Longer name
- Readability

For the uninstall, I only use the `build` for distinguishing, and reason being that, the filter there does not filter down to rc. Currently, the content of the plist in `Contents/version.plist` doesn't identify the release type. And to incorporate release type into the code, we might need to define a convention that might be too strict, and constrained to the cli app.