### PR TITLE
Build And Release Support

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/xcinfo.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/xcinfo.xcscheme
@@ -205,7 +205,23 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "&quot;15&quot;"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "&quot;13.2&quot;"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-b &quot;13C90&quot;"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-r &quot;Release&quot;"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-r &quot;RC 1&quot;"
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--xip-path /Users/trispo/Downloads/Xcode_13.3.xip"
@@ -237,7 +253,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--verbose"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-h"
@@ -245,7 +261,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--no-ansi"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "test"

--- a/Sources/xcinfo/SubCommands/Download.swift
+++ b/Sources/xcinfo/SubCommands/Download.swift
@@ -46,6 +46,9 @@ extension XCInfo {
 
 extension DownloadOptions {
     var options: Core.DownloadOptions {
-        .init(destination: downloadDirectory, disableSleep: disableSleep)
+        .init(destination: downloadDirectory,
+							buildRelease: .init(buildNo: buildReleaseOptions.build,
+																	releaseType: buildReleaseOptions.release),
+							disableSleep: disableSleep)
     }
 }

--- a/Sources/xcinfo/SubCommands/Info.swift
+++ b/Sources/xcinfo/SubCommands/Info.swift
@@ -20,6 +20,9 @@ extension XCInfo {
         @OptionGroup
         var listOptions: ListOptions
 
+				@OptionGroup
+				var buildReleaseOptions: BuildReleaseOptions
+
         @OptionGroup()
         var globals: DefaultOptions
 
@@ -28,7 +31,9 @@ extension XCInfo {
             let environment = Environment.live(isVerboseLoggingEnabled: globals.isVerbose)
             let core = Core(environment: environment)
             do {
-                try await core.info(version: versionOption.xcodeVersion, shouldUpdate: listOptions.updateList)
+                try await core.info(version: versionOption.xcodeVersion,
+																		shouldUpdate: listOptions.updateList,
+																		buildRelease: .init(buildNo: buildReleaseOptions.build, releaseType: buildReleaseOptions.release))
             } catch {
                 environment.logger.error(error.localizedDescription)
                 throw ExitCode.failure

--- a/Sources/xcinfo/SubCommands/Uninstall.swift
+++ b/Sources/xcinfo/SubCommands/Uninstall.swift
@@ -25,12 +25,18 @@ extension XCInfo {
         @OptionGroup
         var listOptions: ListOptions
 
+				@OptionGroup
+				var buildReleaseOptions: BuildReleaseOptions
+
         func run() async throws {
             Rainbow.enabled = globals.useANSI
             let environment = Environment.live(isVerboseLoggingEnabled: globals.isVerbose)
             let core = Core(environment: environment)
             do {
-                try await core.uninstall(xcodeVersion?.lowercased(), updateVersionList: listOptions.updateList)
+							try await core.uninstall(xcodeVersion?.lowercased(),
+																			 buildRelease: .init(buildNo: buildReleaseOptions.build,
+																													 releaseType: buildReleaseOptions.release),
+																			 updateVersionList: listOptions.updateList)
             } catch let error as CoreError {
                 environment.logger.error(error.localizedDescription)
                 throw ExitCode.failure

--- a/Sources/xcinfo/XCInfo.swift
+++ b/Sources/xcinfo/XCInfo.swift
@@ -44,6 +44,14 @@ struct ListOptions: ParsableArguments {
     var updateList = true
 }
 
+struct BuildReleaseOptions: ParsableArguments {
+		@Option(name: .shortAndLong, help: "Build version to use (if provided).")
+		var build: String?
+
+		@Option(name: .shortAndLong, help: "Release name to use (if provided).")
+		var release: String?
+}
+
 struct VersionOptions: ParsableArguments {
     @Argument(
         help: "A version number of an Xcode version or `latest`.",
@@ -66,6 +74,9 @@ struct DownloadOptions: ParsableArguments {
         help: "Let the system sleep during execution."
     )
     var disableSleep: Bool = false
+
+		@OptionGroup
+		var buildReleaseOptions: BuildReleaseOptions
 }
 
 struct ExtractionOptions: ParsableArguments {

--- a/Sources/xcinfoCore/XCReleasesAPI.swift
+++ b/Sources/xcinfoCore/XCReleasesAPI.swift
@@ -60,6 +60,23 @@ extension Xcode: CustomStringConvertible, CustomDebugStringConvertible {
         return components.joined(separator: " ")
     }
 
+		var releaseTitle: String {
+			switch version.release {
+				case .gm:
+					return "GM"
+				case .gmSeed(let gmSeed):
+					return "GM Seed \(gmSeed)"
+				case .rc(let rc):
+					return "RC \(rc)"
+				case .beta(let beta):
+					return "Beta \(beta)"
+				case .dp(let dp):
+					return "DP \(dp)"
+				case .release:
+					return "Release"
+			}
+		}
+
     private var namedVersion: String {
         var components: [String] = []
         if let number = version.number {


### PR DESCRIPTION
## Problem
I was looking at using Xcinfo for managing Xcode on a CI machine, and noticed it needed me to interact with it quite often.

## Observations
I noticed xcinfo reads the session and user information from the keychain for subsequent use, and was able to inject that whenever I need for xcinfo to pickup during installation. But, if I want the CI to run, and just install a single version, that functionality is not available if that particular version has a beta, seed, rc, gm etc.. So, what if I can specify that instead?

## Implementation
I use the `@Options` for adding build and release to `info`, `install`, and `download`. Which is passed down to filter for filtering to specific versions if provided.

I could have use the regex option, but, I see it introducing two non-blocking issues:
- Longer name
- Readability

For the uninstall, I only use the `build` for distinguishing, and reason being that, the filter there does not filter down to rc. Currently, the content of the plist in `Contents/version.plist` doesn't identify the release type. And to incorporate release type into the code, we might need to define a convention that might be too strict, and constrained to the cli app.